### PR TITLE
Добавить автопубликацию на GitHub Pages из пулреквестов

### DIFF
--- a/.github/workflows/gh-pages-on-pr.yml
+++ b/.github/workflows/gh-pages-on-pr.yml
@@ -1,0 +1,47 @@
+name: Deploy on pull request
+
+on:
+  pull_request_target:
+    branches:
+      - '*'
+
+jobs:
+  deploy-on-pull-request:
+    name: Deploy on Pull Request
+
+    permissions:
+      contents: write
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: 'refs/pull/${{ github.event.pull_request.number }}/merge'
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+
+      - name: Restore cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: cache-npm-${{ hashFiles('./package-lock.json') }}
+          restore-keys: cache-npm-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npm run build
+
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: ./build
+          branch: gh-pages
+          target-folder: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
~~С одной стороны~~ этот пулреквест ~~необязательный, без него можно продолжать обучать адаптиву.~~

~~С другой — он и~~ не ломает ничего, но привносит:

- Готовность к дальнейшим улучшениям программы, например появляется возможность перейти на те самы «pretty URL» и сделать студентов ещё чуть ближе к реальным проектам;
- ~~большую гибкость — папка для деплоя прокидывается в экшен из сборщика, а папка, куда будет деплоиться на сервере, забирается из экшена в сборщик для использования например в шаблонизаторе;~~
- ~~а также может чуть разгрузить команду разработки — им можно просто выкинуть функционал с кнопкой «Опубликовать проект» в интерфейсе заданий, потому что теперь экшен делает ровно это — деплоит в подпапку номера пулреквеста в папке имени репозитория, к тому же добавлена возможность перезапустить экшен в интерфейсе экшенов на гитхабе.~~

~~То есть всё, что нужно со стороны академии — это только создать репозиторий студента с начальным наполнением и с включённой веткой `gh-pages`. Все дальнейшие вопросы о «подвисании публикации» уже будут точно не к разработке: «тупит гитхаб, подождите».~~

**UPD:** Добавлен ещё один экшен деплоя, но уже из ветки пулревеста в подпапку с номером пулреквеста (см. ниже).