### PR TITLE
Fix deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "eslint-config-htmlacademy": "10.0.1",
         "gulp": "4.0.2",
         "gulp-esbuild": "0.12.0",
-        "gulp-html-bemlinter": "2.1.4",
+        "gulp-html-bemlinter": "3.0.0",
         "gulp-htmlmin": "5.0.1",
         "gulp-nunjucks": "6.0.0",
         "gulp-plumber": "1.2.1",
@@ -50,12 +50,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.4.tgz",
+      "integrity": "sha512-r1IONyb6Ia+jYR2vvIDhdWdlTGhqbBoFqLTQidzZ4kepUFH15ejXvFHxCVbtl7BOXIudsIubf4E81xeA3h3IXA==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.22.13",
+        "@babel/highlight": "^7.23.4",
         "chalk": "^2.4.2"
       },
       "engines": {
@@ -143,9 +143,9 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.22.20",
@@ -1106,9 +1106,9 @@
       "dev": true
     },
     "node_modules/@types/cors": {
-      "version": "2.8.16",
-      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.16.tgz",
-      "integrity": "sha512-Trx5or1Nyg1Fq138PCuWqoApzvoSLWzZ25ORBiHMbbUT42g578lH1GT4TwYDbiUOLFuDsCkfLneT2105fsFWGg==",
+      "version": "2.8.17",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
+      "integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -1127,9 +1127,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.1.tgz",
-      "integrity": "sha512-HhmzZh5LSJNS5O8jQKpJ/3ZcrrlG6L70hpGqMIAoM9YVD0YBRNWYsfwcXq8VnSjlNpCpgLzMXdiPo+dxcvSmiA==",
+      "version": "20.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.4.tgz",
+      "integrity": "sha512-wmyg8HUhcn6ACjsn8oKYjkN/zUzQeNtMy44weTJSM6p4MMzEOuKbA3OjJ267uPCOW7Xex9dyrNTful8XTQYoDA==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -1148,9 +1148,9 @@
       "dev": true
     },
     "node_modules/@types/vinyl": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@types/vinyl/-/vinyl-2.0.10.tgz",
-      "integrity": "sha512-DqN5BjCrmjAtZ1apqzcq2vk2PSW0m1nFfjIafBFkAyddmHxuw3ZAK3omLiSdpuu81+8h07i6U4DtaE38Xsf2xQ==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/vinyl/-/vinyl-2.0.11.tgz",
+      "integrity": "sha512-vPXzCLmRp74e9LsP8oltnWKTH+jBwt86WgRUb4Pc9Lf3pkMVGyvIo2gm9bODeGfCay2DBB/hAWDuvf07JcK4rw==",
       "dev": true,
       "dependencies": {
         "@types/expect": "^1.20.4",
@@ -2478,9 +2478,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001563",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001563.tgz",
-      "integrity": "sha512-na2WUmOxnwIZtwnFI2CZ/3er0wdNzU7hN+cPYz/z2ajHThnkWjNBOpEPP4n+4r2WPM847JaMotaJE3bnfzjyKw==",
+      "version": "1.0.30001564",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001564.tgz",
+      "integrity": "sha512-DqAOf+rhof+6GVx1y+xzbFPeOumfQnhYzVnZD6LAXijR77yPtm9mfOcqOnT3mpnJiZVT+kwLAFnRlZcIz+c6bg==",
       "dev": true,
       "funding": [
         {
@@ -3798,9 +3798,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.588",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.588.tgz",
-      "integrity": "sha512-soytjxwbgcCu7nh5Pf4S2/4wa6UIu+A3p03U2yVr53qGxi1/VTR3ENI+p50v+UxqqZAfl48j3z55ud7VHIOr9w==",
+      "version": "1.4.593",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.593.tgz",
+      "integrity": "sha512-c7+Hhj87zWmdpmjDONbvNKNo24tvmD4mjal1+qqTYTrlF0/sNpAcDlU0Ki84ftA/5yj3BF2QhSGEC0Rky6larg==",
       "dev": true
     },
     "node_modules/elliptic": {
@@ -6368,15 +6368,18 @@
       }
     },
     "node_modules/gulp-html-bemlinter": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/gulp-html-bemlinter/-/gulp-html-bemlinter-2.1.4.tgz",
-      "integrity": "sha512-Xf34OWD06uEd0aNuKPv3PzdhZtDjdeWPQZgTmxc+ccHZVKzymQKju/vKI8J5snfCqKrnCD5MkanbGf/Sb+s50w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-html-bemlinter/-/gulp-html-bemlinter-3.0.0.tgz",
+      "integrity": "sha512-iqKPaIvzKTqlMRSyXLMJVy2j48bEeBqG8ZuhMu8b5SJbMG1RPLlQOuDtOn04PWXjJinbAF2/qtqTaL7TZqDZUw==",
       "dev": true,
       "dependencies": {
-        "chalk": "^5.2.0",
-        "node-html-parser": "^6.1.5",
+        "chalk": "^5.3.0",
+        "node-html-parser": "^6.1.11",
         "plugin-error": "^2.0.1",
         "through2": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.12 || ^20.9"
       }
     },
     "node_modules/gulp-html-bemlinter/node_modules/chalk": {
@@ -10085,42 +10088,12 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.2.tgz",
-      "integrity": "sha512-Yj9mA8fPiVgOUpByoTZO5pNrcl5Yk37FcSHsUINpAsaBIEZIuqcCclDZJCVxqQShDsmYX8QG63svJiTbOATZwg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
+      "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
       "dev": true,
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
       "engines": {
         "node": "14 || >=16.14"
-      }
-    },
-    "node_modules/path-scurry/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/path-scurry/node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/path-type": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint-config-htmlacademy": "10.0.1",
     "gulp": "4.0.2",
     "gulp-esbuild": "0.12.0",
-    "gulp-html-bemlinter": "2.1.4",
+    "gulp-html-bemlinter": "3.0.0",
     "gulp-htmlmin": "5.0.1",
     "gulp-nunjucks": "6.0.0",
     "gulp-plumber": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,30 @@
   "name": "htmlacademy-gulp-template",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
+  "engines": {
+    "node": "^18.18 || ^20.9"
+  },
+  "browserslist": [
+    "last 2 versions",
+    "not dead",
+    "not op_mini all",
+    "not < 0.25%"
+  ],
+  "scripts": {
+    "lint:spaces": "editorconfig-cli",
+    "lint:styles": "stylelint \"source/styles/**/*.scss\"",
+    "lint:markup": "cd build && html-validator --quiet",
+    "lint:html": "linthtml build/**/*.html --config .linthtmlrc",
+    "lint:bem": "gulp lintBem --silent",
+    "lint:scripts": "eslint . --ignore-path .gitignore",
+    "prelint": "gulp processMarkup --silent",
+    "lint": "npm-run-all -p lint:**",
+    "optimizeImages": "gulp optimizeImages",
+    "start": "gulp runDev",
+    "build": "gulp buildProd",
+    "preview": "gulp buildProd && gulp startServer"
+  },
   "devDependencies": {
     "@htmlacademy/editorconfig-cli": "2.0.8",
     "@linthtml/linthtml": "0.9.5",
@@ -30,29 +54,5 @@
     "stylelint": "15.11.0",
     "stylelint-config-htmlacademy": "2.0.6",
     "w3c-html-validator": "1.6.1"
-  },
-  "scripts": {
-    "lint:spaces": "editorconfig-cli",
-    "lint:styles": "stylelint \"source/styles/**/*.scss\"",
-    "lint:markup": "cd build && html-validator --quiet",
-    "lint:html": "linthtml build/**/*.html --config .linthtmlrc",
-    "lint:bem": "gulp lintBem --silent",
-    "lint:scripts": "eslint . --ignore-path .gitignore",
-    "prelint": "gulp processMarkup --silent",
-    "lint": "npm-run-all -p lint:**",
-    "optimizeImages": "gulp optimizeImages",
-    "start": "gulp runDev",
-    "build": "gulp buildProd",
-    "preview": "gulp buildProd && gulp startServer"
-  },
-  "browserslist": [
-    "last 2 versions",
-    "not dead",
-    "not op_mini all",
-    "not < 0.25%"
-  ],
-  "engines": {
-    "node": "^18.18 || ^20.9"
-  },
-  "type": "module"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "last 2 versions",
     "not dead",
     "not op_mini all",
-    "not < 0.25%"
+    "not and_uc > 0",
+    "not < 0.2%"
   ],
   "scripts": {
     "lint:spaces": "editorconfig-cli",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "lint:spaces": "editorconfig-cli",
     "lint:styles": "stylelint \"source/styles/**/*.scss\"",
-    "lint:markup": "cd build && html-validator --quiet --continue",
+    "lint:markup": "cd build && html-validator --quiet",
     "lint:html": "linthtml build/**/*.html --config .linthtmlrc",
     "lint:bem": "gulp lintBem --silent",
     "lint:scripts": "eslint . --ignore-path .gitignore",


### PR DESCRIPTION
1. Убрал у валидатора опцию, которая оставляет невалидную разметку без статуса ошибки (только ругань в терминале была).
2. Реорганизовал в более удобном порядке поля основного файла проекта: что важнее — то выше.
3. Убрал прокси-браузер из поддерживаемых: такие поддерживать — это надо сидеть с ним конкретно и методом тыка узнавать, что можно, чего нельзя (это явно не для курса).
4. Самое важное: обновил линтер бем-дерева — теперь микс элемента к его же блоку считается ошибкой (был такой косяк в линтере).